### PR TITLE
add support for API v2.1

### DIFF
--- a/traceview/annotation.py
+++ b/traceview/annotation.py
@@ -12,6 +12,10 @@ http://dev.appneta.com/docs/api-v2/annotations.html
 from .resource import Resource
 
 
-class Annotation(Resource):
+class Annotate(Resource):
 
     PATH = "log_message"
+
+class Annotations(Resource):
+
+    PATH = "annotations"

--- a/traceview/app.py
+++ b/traceview/app.py
@@ -15,3 +15,29 @@ from .resource import Resource
 class Assign(Resource):
 
     PATH = "assign_app"
+
+class AppAnnotations(Resource):
+
+    PATH = "app/{app}/annotations"
+
+    def get(self, app, *args, **kwargs):
+        """ Overloaded get method.
+
+        :param str app: The app name to list annotations.
+
+        """
+        self.path = self.PATH.format(app=app)
+        return super(AppAnnotations, self).get(*args, **kwargs)
+
+class AppHosts(Resource):
+
+    PATH = "app/{app}/hosts"
+
+    def get(self, app, *args, **kwargs):
+        """ Overloaded get method.
+
+        :param str app: The app name to list hosts.
+
+        """
+        self.path = self.PATH.format(app=app)
+        return super(AppHosts, self).get(*args, **kwargs)

--- a/traceview/discovery.py
+++ b/traceview/discovery.py
@@ -36,12 +36,6 @@ class Domain(Resource):
 
     PATH = "domains"
 
-
-class Host(Resource):
-
-    PATH = "hosts"
-
-
 class Layer(Resource):
 
     PATH = "layers/{app}"

--- a/traceview/host.py
+++ b/traceview/host.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""
+traceview.hosts
+
+This module contains the objects associated with Hosts API resources.
+
+http://dev.appneta.com/docs/api-v2/hosts.html
+
+"""
+
+from .resource import Resource
+
+
+class Hosts(Resource):
+
+    PATH = "hosts"
+
+class Versions(Resource):
+
+    PATH = "hosts/{host_id}/versions"
+
+    def get(self, host_id, *args, **kwargs):
+        """ Overloaded get method.
+
+        :param str host_id: The host_id to list version information.
+
+        """
+        self.path = self.PATH.format(host_id=host_id)
+        return super(Versions, self).get(*args, **kwargs)
+
+class DeleteHost(Resource):
+
+    PATH = "hosts/{host_id}"
+
+    def delete(self, host_id, *args, **kwargs):
+        """ Overloaded delete method.
+
+        :param str host_id: The host_id to delete.
+
+        """
+        self.path = self.PATH.format(host_id=host_id)
+        return super(DeleteHost, self).delete(*args, **kwargs)

--- a/traceview/organization.py
+++ b/traceview/organization.py
@@ -20,3 +20,7 @@ class Organization(Resource):
 class User(Resource):
 
     PATH = "organization/users"
+
+class Licenses(Resource):
+
+    PATH = "organization/licenses"

--- a/traceview/resource.py
+++ b/traceview/resource.py
@@ -27,7 +27,8 @@ class Resource(object):
     PATH = None
     __methods = [
         'get',
-        'post'
+        'post',
+        'delete'
     ]
 
     def __init__(self, api_key):
@@ -89,3 +90,11 @@ class Resource(object):
 
         """
         return self.request(method='post', *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """ Perform a HTTP DELETE request.
+
+        :param dict kwargs: (optional) Query paramters for the request.
+
+        """
+        return self.request(method='delete', *args, **kwargs)


### PR DESCRIPTION
Add support for the functionality that was added to the TraceView API v2.1.
- Host Discovery API `GET /api-v2/hosts`
- Host Versions API `GET /api-v2/hosts/[host]/versions`
- Host Discovery By App `GET /api-v2/app/[appname]/hosts`
- Host Deletion API `DELETE /api-v2/hosts/[hostname]`
- Organization License API `GET /api-v2/organization/licenses`
- Annotation Read API `GET /api-v2/annotations`
- Annotation Discovery By App `GET /api-v2/app/[appname]/annotations`
