### PR TITLE
add support for Total Requests API

### DIFF
--- a/tests/test_traceview.py
+++ b/tests/test_traceview.py
@@ -19,6 +19,9 @@ import traceview.resource
 
 TV_API_KEY = os.environ.get("TV_API_KEY", None)
 
+# The total_requests API requires a non-default app to measure
+TV_REQUESTS_APP = os.environ.get("TV_REQUESTS_APP", None)
+
 
 ################################################################################
 # API Tests
@@ -133,6 +136,22 @@ class TestErrors(unittest.TestCase):
         self.assertNotEqual(error_rates, None)
         self.assertIsInstance(error_rates, dict)
         self.assertTrue('items' in error_rates)
+
+@unittest.skipIf(TV_API_KEY is None, "No TraceView API Key found in environment.")
+@unittest.skipIf(TV_REQUESTS_APP is None, "TV_REQUESTS_APP must define a valid (non-Default) app in order to test the total_requests API.")
+class TestTotalRequests(unittest.TestCase):
+
+    def setUp(self):
+        self.tv = traceview.TraceView(TV_API_KEY)
+
+    def test_error_rates(self):
+        apps = self.tv.apps()
+        self.assertTrue(len(apps) > 0)
+
+        total_requests = self.tv.total_requests(TV_REQUESTS_APP)
+        self.assertNotEqual(total_requests, None)
+        self.assertIsInstance(total_requests, dict)
+        self.assertTrue('items' in total_requests)
 
 
 @unittest.skipIf(TV_API_KEY is None, "No TraceView API Key found in environment.")

--- a/tests/test_traceview.py
+++ b/tests/test_traceview.py
@@ -20,7 +20,7 @@ import traceview.resource
 TV_API_KEY = os.environ.get("TV_API_KEY", None)
 
 # The total_requests API requires a non-default app to measure
-TV_REQUESTS_APP = os.environ.get("TV_REQUESTS_APP", None)
+TV_APP_NAME = os.environ.get("TV_APP_NAME", None)
 
 
 ################################################################################
@@ -138,7 +138,7 @@ class TestErrors(unittest.TestCase):
         self.assertTrue('items' in error_rates)
 
 @unittest.skipIf(TV_API_KEY is None, "No TraceView API Key found in environment.")
-@unittest.skipIf(TV_REQUESTS_APP is None, "TV_REQUESTS_APP must define a valid (non-Default) app in order to test the total_requests API.")
+@unittest.skipIf(TV_APP_NAME is None, "TV_APP_NAME must define a valid (non-Default) app in order to test the total_requests API.")
 class TestTotalRequests(unittest.TestCase):
 
     def setUp(self):
@@ -148,10 +148,10 @@ class TestTotalRequests(unittest.TestCase):
         apps = self.tv.apps()
         self.assertTrue(len(apps) > 0)
 
-        total_requests = self.tv.total_requests(TV_REQUESTS_APP)
+        total_requests = self.tv.total_requests(TV_APP_NAME)
         self.assertNotEqual(total_requests, None)
         self.assertIsInstance(total_requests, dict)
-        self.assertTrue('items' in total_requests)
+        self.assertIn('items', total_requests)
 
 
 @unittest.skipIf(TV_API_KEY is None, "No TraceView API Key found in environment.")

--- a/traceview/__init__.py
+++ b/traceview/__init__.py
@@ -275,7 +275,7 @@ class TraceView(object):
 
           >>> import traceview
           >>> tv = traceview.TraceView('API KEY HERE')
-          >>> tv.total_requests('Default')
+          >>> tv.total_requests('APP NAME HERE')
           {u'fields': u'timestamp,total_requests', u'items': [[1444650840.0, 583.0], [1444650870.0, 591.0], ...]}
 
         """

--- a/traceview/__init__.py
+++ b/traceview/__init__.py
@@ -22,6 +22,7 @@ from .host import Host, Instrumentation
 from .error import Rate
 from .latency import Client, Server
 from .organization import Organization, User, Licenses
+from .total_request import Requests
 
 
 class TraceView(object):
@@ -57,6 +58,7 @@ class TraceView(object):
         self._organization = Organization(self.api_key)
         self._regions = Region(self.api_key)
         self._users = User(self.api_key)
+        self._total_requests = Requests(self.api_key)
 
         #: Get :py:class:`Client <traceview.latency.Client>` latency information.
         self.client = Client(self.api_key)
@@ -257,6 +259,27 @@ class TraceView(object):
 
         """
         return self._error_rates.get(app, *args, **kwargs)
+
+    def total_requests(self, app, *args, **kwargs):
+        """ Get the total requests for an application.
+
+        Each item in the items list is a pair of values (timestamp,
+        total_requests).  total_requests is the number of requests to
+        your application during that time period.
+
+        :param str app: The application name.
+        :return: timeseries data of the application's total requests
+        :rtype: dict
+
+        Usage::
+
+          >>> import traceview
+          >>> tv = traceview.TraceView('API KEY HERE')
+          >>> tv.total_requests('Default')
+          {u'fields': u'timestamp,total_requests', u'items': [[1444650840.0, 583.0], [1444650870.0, 591.0], ...]}
+
+        """
+        return self._total_requests.get(app, *args, **kwargs)
 
     def hosts(self, appname=None, *args, **kwargs):
         """ Get all hosts that have been traced.

--- a/traceview/total_request.py
+++ b/traceview/total_request.py
@@ -24,4 +24,3 @@ class Requests(Resource):
         """
         self.path = self.PATH.format(app=app)
         return super(Requests, self).get(*args, **kwargs)
-

--- a/traceview/total_request.py
+++ b/traceview/total_request.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+"""
+traceview.total_request
+
+This module contains the objects associated with Total Requests API resources.
+
+http://dev.appneta.com/docs/api-v2/total_requests.html
+
+"""
+
+from .resource import Resource
+
+
+class Requests(Resource):
+
+    PATH = "total_requests/{app}/series"
+
+    def get(self, app, *args, **kwargs):
+        """ Overloaded get method
+
+        :param app: The application name.
+
+        """
+        self.path = self.PATH.format(app=app)
+        return super(Requests, self).get(*args, **kwargs)
+


### PR DESCRIPTION
Hi, We are integrating our app-level latency and volume metrics into Signalfx using python-traceview and I noticed the recently added total_requests API endpoint (http://dev.appneta.com/docs/api-v2/total_requests.html) was not supported - this is a pull request to enable that support.