### PR TITLE
Add app deletion

### DIFF
--- a/tests/test_traceview.py
+++ b/tests/test_traceview.py
@@ -266,20 +266,29 @@ class TestHost(unittest.TestCase):
         self.assertIsInstance(versions, list)
         self.assertIsInstance(versions[0], dict)
 
-
 @unittest.skipIf(TV_API_KEY is None, "No TraceView API Key found in environment.")
-class TestAssign(unittest.TestCase):
+class TestApp(unittest.TestCase):
 
     def setUp(self):
         self.tv = traceview.TraceView(TV_API_KEY)
 
-    def test_assign(self):
+    def test_app_assign(self):
         apps = [app for app in self.tv.apps() if app != 'Default']
         self.assertTrue(len(apps) > 0)
 
         results = self.tv.assign(appname=apps[0], hostname='test.example.com')
         self.assertEqual(results, None)
 
+    def test_app_delete(self):
+        TEST_APP_NAME = 'TEST_APP_ABC123'
+
+        apps = [app for app in self.tv.apps() if app == TEST_APP_NAME]
+        self.assertTrue(len(apps) == 0) # ensure we don't have an app with this name
+
+        results = self.tv.assign(appname=TEST_APP_NAME, hostname='test.example.com', create=True, layer="test")
+
+        results = self.tv.delete_app(app_name=TEST_APP_NAME)
+        self.assertEqual(results, True)
 
 ################################################################################
 # Mocks

--- a/traceview/__init__.py
+++ b/traceview/__init__.py
@@ -207,7 +207,7 @@ class TraceView(object):
         return self._controllers.get()
 
     def delete(self, host_id, *args, **kwargs):
-        """ **Deprecated:** please use delete_host or delete_app.
+        """ **DEPRECATED:** please use delete_host instead.
 
         Delete an existing host.
 
@@ -228,7 +228,7 @@ class TraceView(object):
     def delete_host(self, host_id, *args, **kwargs):
         """ Delete an existing host.
 
-        :param str host_id: The id of the host to delete.
+        :param int host_id: The id of the host to delete.
         :return: indicates if host was successfully deleted.
         :rtype: boolean
 
@@ -236,7 +236,7 @@ class TraceView(object):
 
           >>> usage import traceview
           >>> tv = traceview.TraceView('API KEY HERE')
-          >>> tv.delete_host(host_id='123')
+          >>> tv.delete_host(host_id=123)
           True
 
         """

--- a/traceview/__init__.py
+++ b/traceview/__init__.py
@@ -15,8 +15,8 @@ __license__ = 'MIT'
 
 
 from .annotation import Annotation
-from .app import Assign
-from .discovery import Action, App, Browser, Controller, Domain
+from .app import App, Assign
+from .discovery import Action, Browser, Controller, Domain
 from .discovery import Layer, Metric, Region
 from .host import Host, Instrumentation
 from .error import Rate
@@ -207,7 +207,9 @@ class TraceView(object):
         return self._controllers.get()
 
     def delete(self, host_id, *args, **kwargs):
-        """ Delete an existing host.
+        """ **Deprecated:** please use delete_host or delete_app.
+
+        Delete an existing host.
 
         :param str host_id: The id of the host to delete.
         :return: indicates if host was successfully deleted.
@@ -221,7 +223,41 @@ class TraceView(object):
           True
 
         """
+        return self.delete_host(host_id, *args, **kwargs)
+
+    def delete_host(self, host_id, *args, **kwargs):
+        """ Delete an existing host.
+
+        :param str host_id: The id of the host to delete.
+        :return: indicates if host was successfully deleted.
+        :rtype: boolean
+
+        Usage::
+
+          >>> usage import traceview
+          >>> tv = traceview.TraceView('API KEY HERE')
+          >>> tv.delete_host(host_id='123')
+          True
+
+        """
         return self._hosts.delete(host_id, *args, **kwargs)
+
+    def delete_app(self, app_name, *args, **kwargs):
+        """ Delete an existing app.
+
+        :param str app_name: The name of the app to delete.
+        :return: indicates if app was successfully deleted.
+        :rtype: boolean
+
+        Usage::
+
+          >>> usage import traceview
+          >>> tv = traceview.TraceView('API KEY HERE')
+          >>> tv.delete_app(app_name='APP_123')
+          True
+
+        """
+        return self._apps.delete(app_name, *args, **kwargs)
 
     def domains(self):
         """ Get all domains that have been traced.

--- a/traceview/app.py
+++ b/traceview/app.py
@@ -3,8 +3,10 @@
 """
 traceview.app
 
-This module contains the objects associated with App Management API resources.
+This module contains the objects associated with App Discovery
+and App Management API resources.
 
+http://dev.appneta.com/docs/api-v2/discovery.html
 http://dev.appneta.com/docs/api-v2/app.html
 
 """
@@ -15,3 +17,21 @@ from .resource import Resource
 class Assign(Resource):
 
     PATH = "assign_app"
+
+class App(Resource):
+
+    PATH = {
+        "GET": "apps",
+        "DELETE": "app/{app_name}"
+    }
+    def get(self, *args, **kwargs):
+        self.path = self.PATH["GET"]
+        return super(App, self).get(*args, **kwargs)
+
+    def delete(self, app_name, *args, **kwargs):
+        """ Delete an app.
+
+        :param str app_name: The name of the app to delete.
+        """
+        self.path = self.PATH["DELETE"].format(app_name=app_name)
+        return super(App, self).delete(*args, **kwargs)

--- a/traceview/discovery.py
+++ b/traceview/discovery.py
@@ -17,9 +17,7 @@ class Action(Resource):
     PATH = "actions"
 
 
-class App(Resource):
-
-    PATH = "apps"
+# for App class, see app.py
 
 
 class Browser(Resource):


### PR DESCRIPTION
Due to flat structure of traceview API client class, I also broke the `delete` method into `delete_app` and `delete_host`.  The old `delete` method is still functional (acting on hosts), though it is now documented as deprecated.

Additionally, the `App` discovery class was merged into `app.py`.  It might eventually make sense to break out `App`, `Host`, etc as objects, but given the v2 API doesn't fully parallel this level of organization, I suggest such a change wait on v3.